### PR TITLE
fix #4 (no GH packages to check)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,8 @@ Imports:
     tibble,
     jsonlite,
     magrittr,
-    memoise
+    memoise,
+    clisymbols
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true

--- a/R/gh_helpers.R
+++ b/R/gh_helpers.R
@@ -105,8 +105,8 @@ get_gh_pkgs <- function(package_list){
     purrr::map(package_list,
                ~get_gepuro_data(.)) %>%
     purrr::map(head,1) %>%
-    purrr::reduce(rbind)
-  if(is.data.frame(res)){
+    purrr::reduce(rbind, .init=tibble::tibble())
+  if(nrow(res) > 0){
     res$pkg_location <- res$pkg_name
     res$pkg_org <- vapply(strsplit(res$pkg_location, "/"), `[[`, character(1), 1)
     res$pkg_name <- vapply(strsplit(res$pkg_location, "/"), `[[`, character(1), 2)


### PR DESCRIPTION
#4 is caused by situations where there are _some_ github packages required, but no packages that are not on CRAN that are missing/behind. It may be a result of some change in the behavior of `purrr::reduce` over empty collections.  This changes the behavior of `get_gh_pkgs` slightly: when there are no packages to check, it returns an empty tibble instead of an empty list.

I also added a missing dependency on `clisymbols`